### PR TITLE
Add PublicKey Authentication

### DIFF
--- a/src/ssh2.nim
+++ b/src/ssh2.nim
@@ -1,6 +1,7 @@
 import asyncdispatch, asyncnet, strformat
 from libssh2 import init, free, exit
 import ssh2/private/[agent, channel, types, session]
+export SSHException, AuthenticationException
 
 proc newSSHClient*(): SSHClient =
   if init(0) != 0:
@@ -15,7 +16,7 @@ proc disconnect*(ssh: SSHClient) =
   ssh.socket.close()
   libssh2.exit()
 
-proc connect*(s: SSHClient, hostname: string, username: string, port = Port(22), password = "", useAgent = false) {.async.} =
+proc connect*(s: SSHClient, hostname: string, username: string, port = Port(22), password = "", pkey = "", useAgent = false) {.async.} =
   s.socket = newAsyncSocket()
   await s.socket.connect(hostname, port)
   s.session = initSession()
@@ -32,7 +33,10 @@ proc connect*(s: SSHClient, hostname: string, username: string, port = Port(22),
         break
     agent.close()
   else:
-    discard s.session.authPassword(username, password)
+    if pkey.len != 0:
+      discard s.session.authPublicKey(username, pkey, password)
+    else:
+      discard s.session.authPassword(username, password)
 
 proc execCommand*(s: SSHClient, command: string): Future[(string, string, int)] {.async.} =
   var channel = initChannel(s)

--- a/src/ssh2/private/session.nim
+++ b/src/ssh2/private/session.nim
@@ -1,4 +1,4 @@
-import libssh2, types, strformat, posix
+import os, libssh2, types, strformat, posix
 
 proc initSession*(): Session =
   result = session_init()
@@ -22,6 +22,18 @@ proc authPassword*(session: Session, username, password: string): bool =
       discard
     elif rc < 0:
       raise newException(AuthenticationException, &"Authentication with username {username} and password failed!")
+    else:
+      break
+  result = true
+
+proc authPublicKey*(session: Session; username, pkey: string, passphrase = ""): bool =
+  let pkey = expandTilde(pkey)
+  while true:
+    let rc = session.userauth_publickey_from_file(username, nil, pkey, passphrase)
+    if rc == LIBSSH2_ERROR_EAGAIN:
+      discard
+    elif rc < 0:
+      raise newException(AuthenticationException, &"Authentication with privateKey {pkey} failed!")
     else:
       break
   result = true

--- a/tests/test_exec_pkey.nim
+++ b/tests/test_exec_pkey.nim
@@ -1,0 +1,9 @@
+import asyncdispatch, ssh2, ssh2/scp
+
+proc main() {.async.} =
+  var client = newSSHClient()
+  defer: client.disconnect()
+  await client.connect("127.0.0.1", "nim", Port(22), pkey="~/.ssh/id_rsa", password="secret")
+  echo await client.execCommand("uptime")
+
+waitFor main()


### PR DESCRIPTION
Calls libssh2.userauth_publickey_from_file using nil for the publickey
Does not use the ssh-agent to avoid indicating the passphrase