### PR TITLE
workaround for abiguous session/agent close calls

### DIFF
--- a/src/ssh2.nim
+++ b/src/ssh2.nim
@@ -12,7 +12,7 @@ proc newSSHClient*(): SSHClient =
 
 proc disconnect*(ssh: SSHClient) =
   if ssh.session != nil:
-    ssh.session.close()
+    ssh.session.close_session()
     ssh.session = nil
 
   ssh.socket.close()
@@ -33,7 +33,7 @@ proc connect*(s: SSHClient, hostname: string, username: string, port = Port(22),
     for identity in agent.identities:
       if agent.authenticate(identity, username):
         break
-    agent.close()
+    agent.close_agent()
   else:
     if pkey.len != 0:
       discard s.session.authPublicKey(username, pkey, password)

--- a/src/ssh2/private/agent.nim
+++ b/src/ssh2/private/agent.nim
@@ -42,3 +42,6 @@ proc authenticate*(agent: Agent, identity: AgentPublicKey, username: string): bo
 proc close*(agent: Agent) =
   discard agent.agent_disconnect()
   agent.agentFree()
+
+proc close_agent*(agent: Agent) =
+  close(agent)

--- a/src/ssh2/private/session.nim
+++ b/src/ssh2/private/session.nim
@@ -53,3 +53,6 @@ proc close*(session: Session) =
   while session.session_disconnect("libssh2 wrapper for Nim, libssh2.nim/core") == LIBSSH2_ERROR_EAGAIN:
     discard
   discard session.session_free()
+
+proc close_session*(session: Session) =
+  close(session)

--- a/src/ssh2/scp.nim
+++ b/src/ssh2/scp.nim
@@ -9,7 +9,7 @@ proc initSCPClient*(ssh: SSHClient): SCPClient =
 proc uploadFile*(scp: SCPClient, localPath, remotePath: string) {.async.} =
   ## Upload a file from the local filesystem to the remote SSH server.
   var
-    channel: Channel
+    channel: libssh2.Channel
     buffer: array[1024, char]
     bytesRead: int
     bytesWrite: cint
@@ -46,7 +46,7 @@ proc uploadFile*(scp: SCPClient, localPath, remotePath: string) {.async.} =
 proc downloadFile*(scp: SCPClient, remotePath, localPath: string) {.async.} =
   ## Download a file from the remote SSH server to the local filesystem.
   var
-    channel: Channel
+    channel: libssh2.Channel
     stat: Stat
     bytesRead: int
     buffer: array[1024, char]

--- a/src/ssh2/scp.nim
+++ b/src/ssh2/scp.nim
@@ -52,7 +52,7 @@ proc downloadFile*(scp: SCPClient, remotePath, localPath: string) {.async.} =
     buffer: array[1024, char]
     f: File
   while true:
-    channel = scp.session.scp_recv2(remotePath, addr stat)
+    channel = scp.session.scp_recv(remotePath, stat)
     if channel != nil:
       break
     elif scp.session.session_last_errno() != LIBSSH2_ERROR_EAGAIN:

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -10,4 +10,4 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.0.6", "libssh2 >= 0.1.4"
+requires "nim >= 1.0.6", "libssh2 >= 0.1.6"

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.5"
+version       = "0.1.4"
 author        = "Huy Doan"
 description   = "SSH, SCP and SFTP client for Nim"
 license       = "MIT"

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "Huy Doan"
 description   = "SSH, SCP and SFTP client for Nim"
 license       = "MIT"

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.2"
+version       = "0.1.3"
 author        = "Huy Doan"
 description   = "SSH, SCP and SFTP client for Nim"
 license       = "MIT"

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.3"
+version       = "0.1.5"
 author        = "Huy Doan"
 description   = "SSH, SCP and SFTP client for Nim"
 license       = "MIT"


### PR DESCRIPTION
multiple minor changes.
Added `close_session` and `close_agent` procedures to call respective `close` procs for each type and changed ssh2.nim to call these new procedures instead.
I was unable to effectively cast to each type and call the correct `close` procedure so these new procs work around this leaving the original `close` proc in place.
Also, the scp.nim file has a reference to the libssh2.nim `scp_recv2` proc, which does not exist. I have made changes to call the `scp_recv` proc with the correct parameters for this proc.
