### PR TITLE
create release for compatibility with nim 2.0

### DIFF
--- a/src/ssh2/private/utils.nim
+++ b/src/ssh2/private/utils.nim
@@ -13,7 +13,7 @@ proc waitsocket*(session: Session, socket: AsyncSocket): int =
     readfd: TFdSet
     dir: int
 
-  timeout.tv_sec = 10
+  timeout.tv_sec = 10.Time
   timeout.tv_usec = 0
 
   FD_ZERO(fd)

--- a/ssh2.nimble
+++ b/ssh2.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.4"
+version       = "0.1.5"
 author        = "Huy Doan"
 description   = "SSH, SCP and SFTP client for Nim"
 license       = "MIT"


### PR DESCRIPTION
timeval requires distinct clong for Nim 2.0. this release corrects that 